### PR TITLE
Add prefix to pkgs-variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 - name: Set facts for Debian/Ubuntu
   ansible.builtin.set_fact:
-    pkgs:
+    tmux_pkgs:
       - tmux
       - powerline
   when: ansible_distribution == "Debian" or ansible_distribution == "Ubuntu"
 
 - name: Set facts for Fedora
   ansible.builtin.set_fact:
-    pkgs:
+    tmux_pkgs:
       - tmux
       - powerline
       - tmux-powerline
@@ -17,7 +17,7 @@
 - name: Install packages
   become: true
   ansible.builtin.package:
-    name: "{{ pkgs }}"
+    name: "{{ tmux_pkgs }}"
     state: present
 
 - name: Generate system-wide tmux config


### PR DESCRIPTION
The roles `programs` and `ssh` also use the `pkgs` variable which is set in `vars/`. The `set_fact` in this role overrides this, when both are rolled out at the same time, and `tmux` is executed first.